### PR TITLE
run-blktests: verify the kernel version the test are running on

### DIFF
--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -52,6 +52,12 @@ jobs:
           cat /etc/os-release
           lsblk
 
+      #We create .info files that contain the KERNEL_VERSION tag in the
+      #modules tree when building the kernel
+      - name: Verify that we are running the correct kernel
+        run: |
+          cat /usr/lib/modules/*.info | grep "${KERNEL_VERSION}" 
+
       - name: Install build dependencies for blktests
         run: |
           sudo dnf install -y gcc \


### PR DESCRIPTION
Check kernel version in the VM to match with the previously build kernel artifact. We are generating the .info files that contain the KERNEL_VERSION tag at build time and place it in the modules tree.