### PR TITLE
run-blktests: limit workflow run to single instance

### DIFF
--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -14,7 +14,14 @@ jobs:
     #This step runs in a container in the k8s cluster 
     runs-on: arc-kernel-builder
     steps:
-      - name: Checkout this repo
+      - uses: actions/checkout@v4
+      - name: Wait for other workflow runs to finish before starting the next
+        uses: ahmadnassri/action-workflow-queue@v1
+        with:
+          #Timeout after a week
+          timeout: 604800000
+
+      - name: Checkout blktests-ci
         uses: actions/checkout@v4
         with:
           repository: linux-blktests/blktests-ci


### PR DESCRIPTION
Due to race conditions that need to be adressed in the actions runner we can't run multiple instances of this workflow at the moment.