### PR TITLE
run-blktests: move to single ARC workflow

### DIFF
--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -7,24 +7,18 @@ env:
   KERNEL_REF: "${{ github.event.pull_request.head.sha }}"
   KERNEL_TREE: "https://github.com/${{ github.repository }}"
 
-#This workflow requires two k8s actions-runner-controllers (ARC) to be active.
-#One for building the kernel and fedora image and the other one for spawning the VM resource.
+#This workflow requires an actions-runner-controllers (ARC) to be active.
+#The k8s cluster of this ARC needs KubeVirt to be installed.
 jobs:
   build-kernel:
     #This step runs in a container in the k8s cluster 
-    runs-on: arc-kernel-builder
+    runs-on: arc-vm-shinichiro-linux-block
     steps:
-      - uses: actions/checkout@v4
-      - name: Wait for other workflow runs to finish before starting the next
-        uses: ahmadnassri/action-workflow-queue@v1
-        with:
-          #Timeout after a week
-          timeout: 604800000
-
       - name: Checkout blktests-ci
         uses: actions/checkout@v4
         with:
-          repository: linux-blktests/blktests-ci
+          repository: MaisenbacherD/blktests-ci
+          ref: "fix-arc"
           path: blktests-ci
 
       - name: Build kernel and package it into a containerimage
@@ -43,77 +37,56 @@ jobs:
           docker tag linux-kernel-containerdisk registry-service.docker-registry.svc.cluster.local/linux-kernel-containerdisk:${KERNEL_VERSION}
           docker push registry-service.docker-registry.svc.cluster.local/linux-kernel-containerdisk:${KERNEL_VERSION}
 
-      - name: Notifying the next job to pick up the Fedora image with the correct tag that we just build
-        run: |
-          echo "${KERNEL_VERSION}"
-
-  run-tests-on-kernel:
-    #ATTENTION! This section formats all available NVMe devices. Be careful when changing the `runs-on` tag!
-    #This step runs in a VM with the previously compiled kernel in the k8s cluster 
-    runs-on: arc-vm-runner-set
-    needs: build-kernel
-    steps:
-      - name: Print VM debug info
-        run: |
-          uname -a
-          cat /etc/os-release
-          lsblk
-
-      #We create .info files that contain the KERNEL_VERSION tag in the
-      #modules tree when building the kernel
-      - name: Verify that we are running the correct kernel
-        run: |
-          cat /usr/lib/modules/*.info | grep "${KERNEL_VERSION}" 
-
-      - name: Install build dependencies for blktests
-        run: |
-          sudo dnf install -y gcc \
-          clang \
-          make \
-          util-linux \
-          llvm \
-          gawk \
-          fio \
-          udev \
-          kmod \
-          coreutils \
-          gcc \
-          gzip \
-          e2fsprogs \
-          xfsprogs \
-          f2fs-tools \
-          btrfs-progs \
-          device-mapper-multipath \
-          nbd \
-          device-mapper \
-          unzip \
-          jq \
-          nvme-cli \
-          git \
-          wget
-
-      - name: Checkout blktests
-        uses: actions/checkout@v4
+      - name: Run in VM
+        uses: blktests-ci/.github/actions/kubevirt-action
         with:
-          repository: osandov/blktests
-          path: blktests
+          kernel_version: ${{ env.KERNEL_VERSION }}
+          run_cmds: |
+            #Print VM debug info
+            uname -a
+            cat /etc/os-release
+            lsblk
 
-      - name: Build blktests
-        run: |
-          cd blktests
-          make
+            #Install build dependencies for blktests
+            sudo dnf install -y gcc \
+            clang \
+            make \
+            util-linux \
+            llvm \
+            gawk \
+            fio \
+            udev \
+            kmod \
+            coreutils \
+            gcc \
+            gzip \
+            e2fsprogs \
+            xfsprogs \
+            f2fs-tools \
+            btrfs-progs \
+            device-mapper-multipath \
+            nbd \
+            device-mapper \
+            unzip \
+            jq \
+            nvme-cli \
+            git \
+            wget
 
-      - name: Configure blktests
-        run: |
-          cd blktests
-          cat > config << EOF
-          TEST_DEVS=(${ZBD0})
-          DEVICE_ONLY=1
-          EOF
+            git clone https://github.com/linux-blktests/blktests.git
 
-      - name: Run ZBD Tests
-        run: |
-          cd blktests
-          sudo ./check zbd
-        env: 
-          RUN_ZONED_TESTS: 1
+            cd blktests
+            make
+
+            cat > config << EOF
+            TEST_DEVS=(${ZBD0})
+            DEVICE_ONLY=1
+            EOF
+
+            #ATTENTION! This section formats all available NVMe devices. Be careful when changing the `runs-on` tag!
+            #This step runs in a VM with the previously compiled kernel in the k8s cluster 
+
+            # Run ZBD blktests
+
+            export RUN_ZONED_TESTS=1
+            sudo ./check zbd


### PR DESCRIPTION
Using a single GitHub Actions Resource Controller that is capable of spawning a KubeVirt VM. With this setup we are avoiding the concurrency issues we had.

We are now spawning the VM in place with the new `kubevirt-action`.